### PR TITLE
Bad recursion!

### DIFF
--- a/shared/BaseGateway.cs
+++ b/shared/BaseGateway.cs
@@ -138,7 +138,7 @@ namespace Moonlight.Shared.Internal.Events
         {
             Logger.Debug($"Mounted: {endpoint}");
 
-            Mount(endpoint, @delegate);
+             _subscriptions.Add(new EventSubscription(endpoint, @delegate));
         }
 
         protected abstract Task GetDelayedTask(int milliseconds = 0);


### PR DESCRIPTION
Mount calling itself into an infinite recursion would lead to a bad server crash upon start!!
+ no events were getting actually mounted if not added in the _subscriptions List